### PR TITLE
Support scalars and plain numpy arrays in every operation currently supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/

--- a/mpi4jax/collective_ops/send.py
+++ b/mpi4jax/collective_ops/send.py
@@ -51,11 +51,7 @@ def mpi_send_xla_encode(c, x, token, dest, tag, comm):
     dims = x_shape.dimensions()
 
     # compute total number of elements in array
-    nitems = dims[0]
-    for el in dims[1:]:
-        nitems *= el
-
-    _nitems = _constant_s32_scalar(c, nitems)
+    _nitems = _constant_s32_scalar(c, _np.prod(dims, dtype=int))
     _dtype_ptr = dtype_ptr(dtype)
 
     # ensure void** out type

--- a/tests/test_mpi4jax.py
+++ b/tests/test_mpi4jax.py
@@ -47,6 +47,28 @@ def test_allreduce_jit():
     assert jnp.array_equal(_arr, arr)
 
 
+def test_allreduce_scalar():
+    from mpi4jax import Allreduce
+
+    arr = 1
+    _arr = 1
+
+    res, token = Allreduce(arr, op=MPI.SUM)
+    assert jnp.array_equal(res, arr * size)
+    assert jnp.array_equal(_arr, arr)
+
+
+def test_allreduce_scalar_jit():
+    from mpi4jax import Allreduce
+
+    arr = 1
+    _arr = 1
+
+    res, token = jax.jit(lambda x: Allreduce(x, op=MPI.SUM))(arr)
+    assert jnp.array_equal(res, arr * size)
+    assert jnp.array_equal(_arr, arr)
+
+
 def test_send_recv():
     from mpi4jax import Send, Recv
 

--- a/tests/test_mpi4jax.py
+++ b/tests/test_mpi4jax.py
@@ -85,6 +85,38 @@ def test_send_recv():
         assert jnp.array_equal(_arr, arr)
 
 
+def test_send_recv_scalar():
+    from mpi4jax import Send, Recv
+
+    arr = 1 * rank
+    _arr = 1 * rank
+
+    if rank == 0:
+        for proc in range(1, size):
+            res, token = Recv(arr, source=proc, tag=proc)
+            assert jnp.array_equal(res, jnp.ones_like(arr) * proc)
+            assert jnp.array_equal(_arr, arr)
+    else:
+        Send(arr, 0, tag=rank)
+        assert jnp.array_equal(_arr, arr)
+
+
+def test_send_recv_scalar_jit():
+    from mpi4jax import Send, Recv
+
+    arr = 1 * rank
+    _arr = 1 * rank
+
+    if rank == 0:
+        for proc in range(1, size):
+            res, token = jax.jit(lambda x: Recv(x, source=proc, tag=proc))(arr)
+            assert jnp.array_equal(res, jnp.ones_like(arr) * proc)
+            assert jnp.array_equal(_arr, arr)
+    else:
+        jax.jit(lambda x: Send(x, 0, tag=rank))(arr)
+        assert jnp.array_equal(_arr, arr)
+
+
 def test_send_recv_jit():
     from mpi4jax import Send, Recv
 

--- a/tests/test_mpi4jax.py
+++ b/tests/test_mpi4jax.py
@@ -191,11 +191,43 @@ def test_sendrecv():
 
 
 @pytest.mark.skipif(size < 2 or rank > 1, reason="Runs only on rank 0 and 1")
+def test_sendrecv_scalar():
+    from mpi4jax import Sendrecv
+
+    arr = 1 * rank
+    _arr = arr
+
+    other = 1 - rank
+
+    res, token = Sendrecv(arr, arr, source=other, dest=other)
+
+    assert jnp.array_equal(res, jnp.ones_like(arr) * other)
+    assert jnp.array_equal(_arr, arr)
+
+
+@pytest.mark.skipif(size < 2 or rank > 1, reason="Runs only on rank 0 and 1")
 def test_sendrecv_jit():
     from mpi4jax import Sendrecv
 
     arr = jnp.ones((3, 2)) * rank
     _arr = arr.copy()
+
+    other = 1 - rank
+
+    res, token = jax.jit(lambda x, y: Sendrecv(x, y, source=other, dest=other))(
+        arr, arr
+    )
+
+    assert jnp.array_equal(res, jnp.ones_like(arr) * other)
+    assert jnp.array_equal(_arr, arr)
+
+
+@pytest.mark.skipif(size < 2 or rank > 1, reason="Runs only on rank 0 and 1")
+def test_sendrecv_scalar_jit():
+    from mpi4jax import Sendrecv
+
+    arr = 1 * rank
+    _arr = arr
 
     other = 1 - rank
 


### PR DESCRIPTION
Uses `_np.prod` to compute length of size, which for empty tuples handily returns 1.

@dionhaefner maybe this will be useless if we decide to only keep the Cython code, but for now lets add it... 

Let me know what you think