### PR TITLE
Always use Cython implementation

### DIFF
--- a/mpi4jax/collective_ops/allreduce.py
+++ b/mpi4jax/collective_ops/allreduce.py
@@ -102,7 +102,7 @@ def mpi_allreduce_abstract_eval(xs, token, op, comm):
 
 
 mpi_allreduce_p.multiple_results = True
-mpi_allreduce_p.def_impl(default_primitive_impl(mpi_allreduce_p))
+mpi_allreduce_p.def_impl(mpi_allreduce_impl)
 mpi_allreduce_p.def_abstract_eval(mpi_allreduce_abstract_eval)
 
 # assign to the primitive the correct encoder

--- a/mpi4jax/collective_ops/allreduce.py
+++ b/mpi4jax/collective_ops/allreduce.py
@@ -109,6 +109,8 @@ def mpi_allreduce_value_and_jvp(in_args, tan_args, op, comm):
     res = Allreduce(x, token=token, op=op, comm=comm)
 
     # Identify the correct adjoint
+    op = unpack_hashable(op)
+
     if op == _MPI.SUM:
         jvp = (x_tan, token_tan)
     else:

--- a/mpi4jax/collective_ops/recv.py
+++ b/mpi4jax/collective_ops/recv.py
@@ -17,12 +17,14 @@ from ..utils import (
     dtype_ptr,
     wrap_as_hashable,
     unpack_hashable,
+    default_primitive_impl,
 )
 
 from ..warn import warn_missing_omnistaging
 
 # The Jax primitive
 mpi_recv_p = Primitive("recv_mpi")  # Create the primitive
+mpi_recv_impl = default_primitive_impl(mpi_recv_p)
 
 
 # This function applies the primitive to an AST
@@ -37,16 +39,8 @@ def Recv(
     if token is None:
         token = create_token(x)
 
-    out = mpi_recv_p.bind(x, token, source=source, tag=tag, comm=comm, status=status)
-    return out
-
-
-#  this function executes the primitive, when not under any transformation
-def mpi_recv_impl(x, token, source, tag, comm, status):
     comm = wrap_as_hashable(comm)
-    return xla.apply_primitive(
-        mpi_recv_p, x, token, source=source, tag=tag, comm=comm, status=status
-    )
+    return mpi_recv_p.bind(x, token, source=source, tag=tag, comm=comm, status=status)
 
 
 #  This function compiles the operation

--- a/mpi4jax/collective_ops/send.py
+++ b/mpi4jax/collective_ops/send.py
@@ -17,6 +17,7 @@ from ..utils import (
     dtype_ptr,
     wrap_as_hashable,
     unpack_hashable,
+    default_primitive_impl,
 )
 
 from ..warn import warn_missing_omnistaging
@@ -24,6 +25,7 @@ from ..warn import warn_missing_omnistaging
 
 # The Jax primitive
 mpi_send_p = Primitive("send_mpi")  # Create the primitive
+mpi_send_impl = default_primitive_impl(mpi_send_p)
 
 
 # This function applies the primitive to an AST
@@ -31,14 +33,8 @@ def Send(x, dest, tag=0, comm=_MPI.COMM_WORLD, token=None):
     if token is None:
         token = create_token(x)
 
-    out = mpi_send_p.bind(x, token, dest=dest, tag=tag, comm=comm)
-    return out
-
-
-#  this function executes the primitive, when not under any transformation
-def mpi_send_impl(x, token, dest, tag, comm):
     comm = wrap_as_hashable(comm)
-    return xla.apply_primitive(mpi_send_p, x, token, dest=dest, tag=tag, comm=comm)
+    return mpi_send_p.bind(x, token, dest=dest, tag=tag, comm=comm)
 
 
 #  This function compiles the operation

--- a/mpi4jax/collective_ops/send.py
+++ b/mpi4jax/collective_ops/send.py
@@ -99,7 +99,6 @@ def mpi_send_abstract_eval(xs, token, dest, tag, comm):
     return abstract_arrays.abstract_token
 
 
-# mpi_send_p.multiple_results = True
 mpi_send_p.def_impl(mpi_send_impl)
 mpi_send_p.def_abstract_eval(mpi_send_abstract_eval)
 

--- a/mpi4jax/collective_ops/send.py
+++ b/mpi4jax/collective_ops/send.py
@@ -34,11 +34,8 @@ def Send(x, dest, tag=0, comm=_MPI.COMM_WORLD, token=None):
 
 
 #  this function executes the primitive, when not under any transformation
-def mpi_send_impl(x, token, dest, tag, comm):
-    # TODO: make this support gpus (use cupy?)
-    inpt = _np.asarray(x)
-    comm.Send(inpt, dest=dest, tag=tag)
-    return token
+def mpi_send_impl(*args, **kwargs):
+    xla.apply_primitive(mpi_send_p, *args, **kwargs)
 
 
 #  This function compiles the operation

--- a/mpi4jax/collective_ops/sendrecv.py
+++ b/mpi4jax/collective_ops/sendrecv.py
@@ -17,12 +17,14 @@ from ..utils import (
     dtype_ptr,
     wrap_as_hashable,
     unpack_hashable,
+    default_primitive_impl,
 )
 
 from ..warn import warn_missing_omnistaging
 
 # The Jax primitive
 mpi_sendrecv_p = Primitive("sendrecv_mpi")  # Create the primitive
+mpi_sendrecv_impl = default_primitive_impl(mpi_sendrecv_p)
 
 
 # This function applies the primitive to an AST
@@ -40,26 +42,8 @@ def Sendrecv(
     if token is None:
         token = create_token(sendbuf)
 
-    return mpi_sendrecv_p.bind(
-        sendbuf,
-        recvbuf,
-        token,
-        source=source,
-        dest=dest,
-        sendtag=sendtag,
-        recvtag=recvtag,
-        comm=comm,
-        status=status,
-    )
-
-
-#  this function executes the primitive, when not under any transformation
-def mpi_sendrecv_impl(
-    sendbuf, recvbuf, token, source, dest, sendtag, recvtag, comm, status
-):
     comm = wrap_as_hashable(comm)
-    return xla.apply_primitive(
-        mpi_sendrecv_p,
+    return mpi_sendrecv_p.bind(
         sendbuf,
         recvbuf,
         token,

--- a/mpi4jax/utils.py
+++ b/mpi4jax/utils.py
@@ -1,10 +1,16 @@
+import functools
 import numpy as _np
 
 from mpi4py import MPI as _MPI
 
 from jax.lib import xla_client
+from jax.interpreters import xla
 
 _ops = xla_client.ops
+
+
+def default_primitive_impl(primitive):
+    return functools.partial(xla.apply_primitive, primitive)
 
 
 def to_mpi_ptr(mpi_obj):

--- a/mpi4jax/utils.py
+++ b/mpi4jax/utils.py
@@ -62,6 +62,9 @@ class HashableMPIType:
 
 
 def wrap_as_hashable(obj):
+    if isinstance(obj, HashableMPIType):
+        return obj
+
     return HashableMPIType(obj)
 
 


### PR DESCRIPTION
What do you think of this? I had to introduce a hashable dummy type to work around https://github.com/google/jax/issues/4280, but I kinda like it because it uses the memory address of the underlying MPI object for caching (which should be more invariant than object id).

This removes quite a bit of boilerplate from the primitive implementations.

Fixes #9