### PR TITLE
Reintroduce Allreduce gradient

### DIFF
--- a/mpi4jax/__init__.py
+++ b/mpi4jax/__init__.py
@@ -2,6 +2,8 @@ import mpi4jax.cython  # noqa: F401
 
 __all__ = ["Allreduce", "Send", "Recv", "Sendrecv"]
 
+from ._create_token import create_token
+
 from .collective_ops.allreduce import Allreduce
 from .collective_ops.send import Send
 from .collective_ops.recv import Recv

--- a/mpi4jax/_create_token.py
+++ b/mpi4jax/_create_token.py
@@ -1,0 +1,42 @@
+"""
+This file defines a create_token operation analogous to the jax.lax one,
+but for which we also define the gradient, so that it plays nice with AD.
+"""
+from jax.lax import create_token, zeros_like_array
+from jax.lax.lax import create_token_p
+from jax.core import Primitive
+from jax.util import partial
+from jax.abstract_arrays import abstract_token
+from jax.interpreters import xla, ad
+from jax.lib import xla_client
+
+
+def create_token(x):
+    """Creates an XLA token value with no preconditions for sequencing effects.
+    This is a mpi4jax customized version, which behaves as the jax one but it
+    is also possible to compute the gradient of it.
+
+    Experimental.
+
+    Args:
+      x: a dummy argument used to tie the CreateToken operator into a trace. The
+         value of `x` is ignored.
+    """
+    # x is a dummy argument used to tie the operator into a trace.
+    return create_token_p.bind(x)
+
+
+create_token_p = Primitive("create_token_mpi4jax")
+create_token_p.def_impl(partial(xla.apply_primitive, create_token_p))
+create_token_p.def_abstract_eval(lambda _: abstract_token)
+xla.translations[create_token_p] = lambda c, _: xla_client.ops.CreateToken(c)
+
+
+def create_token_value_and_jvp(in_args, tan_args):
+    (x,) = in_args
+    res = create_token(x)
+    jvp = zeros_like_array(x)
+    return (res, jvp)
+
+
+ad.primitive_jvps[create_token_p] = create_token_value_and_jvp

--- a/mpi4jax/collective_ops/allreduce.py
+++ b/mpi4jax/collective_ops/allreduce.py
@@ -4,11 +4,11 @@ from mpi4py import MPI as _MPI
 
 from jax import abstract_arrays, device_put
 from jax import numpy as jnp
-from jax.lax import create_token, zeros_like_array
-from jax.lax.lax import create_token_p
 from jax.core import Primitive
 from jax.lib import xla_client
 from jax.interpreters import xla, ad
+
+from .. import create_token
 
 from ..utils import (
     to_mpi_ptr,
@@ -138,18 +138,3 @@ ad.primitive_jvps[mpi_allreduce_p] = mpi_allreduce_value_and_jvp
 
 # assign to the primitive the correct encoder
 xla.backend_specific_translations["cpu"][mpi_allreduce_p] = mpi_allreduce_xla_encode
-
-
-# This is a fix to the fact that `jax.lax.create_token` does not have an
-# adjoint defined, so we define it here.
-# Hopefully this issue will be resolved in upstream at a later date
-def create_token_value_and_jvp(in_args, tan_args):
-    print("create in; ", in_args)
-    print("create tan_in: ", tan_args)
-    (x,) = in_args
-    res = create_token(x)
-    jvp = zeros_like_array(x)
-    return (res, jvp)
-
-
-ad.primitive_jvps[create_token_p] = create_token_value_and_jvp

--- a/mpi4jax/collective_ops/allreduce.py
+++ b/mpi4jax/collective_ops/allreduce.py
@@ -4,10 +4,11 @@ from mpi4py import MPI as _MPI
 
 from jax import abstract_arrays, device_put
 from jax import numpy as jnp
-from jax.lax import create_token
+from jax.lax import create_token, zeros_like_array
+from jax.lax.lax import create_token_p
 from jax.core import Primitive
 from jax.lib import xla_client
-from jax.interpreters import xla
+from jax.interpreters import xla, ad
 
 from ..utils import (
     to_mpi_ptr,
@@ -112,9 +113,43 @@ def mpi_allreduce_abstract_eval(xs, token, op, comm):
     )
 
 
+def mpi_allreduce_value_and_jvp(in_args, tan_args, op, comm):
+    x, token = in_args
+    x_tan, token_tan = tan_args
+
+    res = Allreduce(x, token=token, op=op, comm=comm)
+
+    # Identify the correct adjoint
+    if op == _MPI.SUM:
+        jvp = (x_tan, token_tan)
+    else:
+        raise NotImplementedError(
+            "The adjoint of allreduce for {} operation is not defined".format(op)
+        )
+
+    return (res, jvp)
+
+
 mpi_allreduce_p.multiple_results = True
 mpi_allreduce_p.def_impl(mpi_allreduce_impl)
 mpi_allreduce_p.def_abstract_eval(mpi_allreduce_abstract_eval)
 
+ad.primitive_jvps[mpi_allreduce_p] = mpi_allreduce_value_and_jvp
+
 # assign to the primitive the correct encoder
 xla.backend_specific_translations["cpu"][mpi_allreduce_p] = mpi_allreduce_xla_encode
+
+
+# This is a fix to the fact that `jax.lax.create_token` does not have an
+# adjoint defined, so we define it here.
+# Hopefully this issue will be resolved in upstream at a later date
+def create_token_value_and_jvp(in_args, tan_args):
+    print("create in; ", in_args)
+    print("create tan_in: ", tan_args)
+    (x,) = in_args
+    res = create_token(x)
+    jvp = zeros_like_array(x)
+    return (res, jvp)
+
+
+ad.primitive_jvps[create_token_p] = create_token_value_and_jvp

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if HAS_CYTHON:
 
 setup(
     name="mpi4jax",
-    version="0.2.3",
+    version="0.2.5",
     author="Filippo Vicentini",
     author_email="filippovicentini@gmail.com",
     long_description="""Jax-mpi provides integration among jax and MPI, so that


### PR DESCRIPTION
This works by defining an adjoint for the `jax.lax.create_token` primitive.
Seems to work fine, though maybe @matthj could tell us if what we are doing is fine.