### PR TITLE
Validate types during runtime

### DIFF
--- a/mpi4jax/__init__.py
+++ b/mpi4jax/__init__.py
@@ -1,7 +1,5 @@
 import mpi4jax.cython  # noqa: F401
 
-__all__ = ["Allreduce", "Send", "Recv", "Sendrecv"]
-
 from ._create_token import create_token
 
 from .collective_ops.allreduce import Allreduce
@@ -10,3 +8,12 @@ from .collective_ops.recv import Recv
 from .collective_ops.sendrecv import Sendrecv
 
 from .warn import disable_omnistaging_warning
+
+__all__ = [
+    "Allreduce",
+    "Send",
+    "Recv",
+    "Sendrecv",
+    "create_token",
+    "disable_omnistaging_warning",
+]

--- a/mpi4jax/collective_ops/allreduce.py
+++ b/mpi4jax/collective_ops/allreduce.py
@@ -2,7 +2,7 @@ import numpy as _np
 
 from mpi4py import MPI as _MPI
 
-from jax import abstract_arrays
+from jax import abstract_arrays, core
 from jax.core import Primitive
 from jax.lib import xla_client
 from jax.interpreters import xla, ad
@@ -19,9 +19,11 @@ from ..utils import (
     wrap_as_hashable,
     unpack_hashable,
     default_primitive_impl,
+    HashableMPIType,
 )
 
 from ..warn import warn_missing_omnistaging
+from ..validation import enforce_types
 
 # The Jax primitive
 mpi_allreduce_p = Primitive("allreduce_mpi")  # Create the primitive
@@ -29,6 +31,11 @@ mpi_allreduce_impl = default_primitive_impl(mpi_allreduce_p)
 
 
 # This function applies the primitive to an AST
+@enforce_types(
+    op=(_MPI.Op, HashableMPIType),
+    comm=(_MPI.Intracomm, HashableMPIType),
+    token=(type(None), xla.Token, core.Tracer),
+)
 def Allreduce(x, op, comm=_MPI.COMM_WORLD, token=None):
     """
     Allreduce(x, op, comm=_MPI.COMM_WORLD, token=None)

--- a/mpi4jax/collective_ops/recv.py
+++ b/mpi4jax/collective_ops/recv.py
@@ -2,7 +2,7 @@ import numpy as _np
 
 from mpi4py import MPI as _MPI
 
-from jax import abstract_arrays
+from jax import abstract_arrays, core
 from jax.lax import create_token
 from jax.core import Primitive
 from jax.lib import xla_client
@@ -18,9 +18,11 @@ from ..utils import (
     wrap_as_hashable,
     unpack_hashable,
     default_primitive_impl,
+    HashableMPIType,
 )
 
 from ..warn import warn_missing_omnistaging
+from ..validation import enforce_types
 
 # The Jax primitive
 mpi_recv_p = Primitive("recv_mpi")  # Create the primitive
@@ -28,6 +30,13 @@ mpi_recv_impl = default_primitive_impl(mpi_recv_p)
 
 
 # This function applies the primitive to an AST
+@enforce_types(
+    source=int,
+    tag=int,
+    comm=(_MPI.Intracomm, HashableMPIType),
+    status=(type(None), _MPI.Status),
+    token=(type(None), xla.Token, core.Tracer),
+)
 def Recv(
     x,
     source=_MPI.ANY_SOURCE,

--- a/mpi4jax/collective_ops/recv.py
+++ b/mpi4jax/collective_ops/recv.py
@@ -31,10 +31,10 @@ mpi_recv_impl = default_primitive_impl(mpi_recv_p)
 
 # This function applies the primitive to an AST
 @enforce_types(
-    source=int,
-    tag=int,
+    source=_np.integer,
+    tag=_np.integer,
     comm=(_MPI.Intracomm, HashableMPIType),
-    status=(type(None), _MPI.Status),
+    status=(type(None), _MPI.Status, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
 def Recv(
@@ -71,6 +71,10 @@ def Recv(
         token = create_token(x)
 
     comm = wrap_as_hashable(comm)
+
+    if status is not None:
+        status = wrap_as_hashable(status)
+
     return mpi_recv_p.bind(x, token, source=source, tag=tag, comm=comm, status=status)
 
 
@@ -81,6 +85,7 @@ def mpi_recv_xla_encode(c, x, token, source, tag, comm, status):
     warn_missing_omnistaging()
 
     comm = unpack_hashable(comm)
+    status = unpack_hashable(status)
 
     c = _unpack_builder(c)
     x_shape = c.GetShape(x)

--- a/mpi4jax/collective_ops/send.py
+++ b/mpi4jax/collective_ops/send.py
@@ -32,8 +32,8 @@ mpi_send_impl = default_primitive_impl(mpi_send_p)
 
 # This function applies the primitive to an AST
 @enforce_types(
-    dest=int,
-    tag=int,
+    dest=_np.integer,
+    tag=_np.integer,
     comm=(_MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )

--- a/mpi4jax/collective_ops/send.py
+++ b/mpi4jax/collective_ops/send.py
@@ -2,7 +2,7 @@ import numpy as _np
 
 from mpi4py import MPI as _MPI
 
-from jax import abstract_arrays
+from jax import abstract_arrays, core
 from jax.lax import create_token
 from jax.core import Primitive
 from jax.lib import xla_client
@@ -18,9 +18,11 @@ from ..utils import (
     wrap_as_hashable,
     unpack_hashable,
     default_primitive_impl,
+    HashableMPIType,
 )
 
 from ..warn import warn_missing_omnistaging
+from ..validation import enforce_types
 
 
 # The Jax primitive
@@ -29,6 +31,12 @@ mpi_send_impl = default_primitive_impl(mpi_send_p)
 
 
 # This function applies the primitive to an AST
+@enforce_types(
+    dest=int,
+    tag=int,
+    comm=(_MPI.Intracomm, HashableMPIType),
+    token=(type(None), xla.Token, core.Tracer),
+)
 def Send(x, dest, tag=0, comm=_MPI.COMM_WORLD, token=None):
     """
     Send(x, dest, tag=0, comm=_MPI.COMM_WORLD, token=None)

--- a/mpi4jax/collective_ops/sendrecv.py
+++ b/mpi4jax/collective_ops/sendrecv.py
@@ -31,12 +31,12 @@ mpi_sendrecv_impl = default_primitive_impl(mpi_sendrecv_p)
 
 # This function applies the primitive to an AST
 @enforce_types(
-    source=int,
-    dest=int,
-    sendtag=int,
-    recvtag=int,
+    source=_np.integer,
+    dest=_np.integer,
+    sendtag=_np.integer,
+    recvtag=_np.integer,
     comm=(_MPI.Intracomm, HashableMPIType),
-    status=(type(None), _MPI.Status),
+    status=(type(None), _MPI.Status, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
 def Sendrecv(
@@ -54,6 +54,10 @@ def Sendrecv(
         token = create_token(sendbuf)
 
     comm = wrap_as_hashable(comm)
+
+    if status is not None:
+        status = wrap_as_hashable(status)
+
     return mpi_sendrecv_p.bind(
         sendbuf,
         recvbuf,
@@ -76,6 +80,7 @@ def mpi_sendrecv_xla_encode(
     warn_missing_omnistaging()
 
     comm = unpack_hashable(comm)
+    status = unpack_hashable(status)
 
     c = _unpack_builder(c)
 

--- a/mpi4jax/collective_ops/sendrecv.py
+++ b/mpi4jax/collective_ops/sendrecv.py
@@ -2,7 +2,7 @@ import numpy as _np
 
 from mpi4py import MPI as _MPI
 
-from jax import abstract_arrays
+from jax import abstract_arrays, core
 from jax.lax import create_token
 from jax.core import Primitive
 from jax.lib import xla_client
@@ -18,9 +18,11 @@ from ..utils import (
     wrap_as_hashable,
     unpack_hashable,
     default_primitive_impl,
+    HashableMPIType,
 )
 
 from ..warn import warn_missing_omnistaging
+from ..validation import enforce_types
 
 # The Jax primitive
 mpi_sendrecv_p = Primitive("sendrecv_mpi")  # Create the primitive
@@ -28,6 +30,15 @@ mpi_sendrecv_impl = default_primitive_impl(mpi_sendrecv_p)
 
 
 # This function applies the primitive to an AST
+@enforce_types(
+    source=int,
+    dest=int,
+    sendtag=int,
+    recvtag=int,
+    comm=(_MPI.Intracomm, HashableMPIType),
+    status=(type(None), _MPI.Status),
+    token=(type(None), xla.Token, core.Tracer),
+)
 def Sendrecv(
     sendbuf,
     recvbuf,

--- a/mpi4jax/flush.py
+++ b/mpi4jax/flush.py
@@ -4,6 +4,6 @@ import jax
 def flush():
     """Wait for all pending XLA operations"""
     # as suggested in jax#4335
-    for device in jax.devices('cpu'):
+    for device in jax.devices("cpu"):
         noop = jax.device_put(0, device=device) + 0
         noop.block_until_ready()

--- a/mpi4jax/flush.py
+++ b/mpi4jax/flush.py
@@ -4,5 +4,6 @@ import jax
 def flush():
     """Wait for all pending XLA operations"""
     # as suggested in jax#4335
-    noop = jax.device_put(0, device='cpu') + 0
-    noop.block_until_ready()
+    for device in jax.devices('cpu'):
+        noop = jax.device_put(0, device=device) + 0
+        noop.block_until_ready()

--- a/mpi4jax/validation.py
+++ b/mpi4jax/validation.py
@@ -1,0 +1,79 @@
+import inspect
+import functools
+
+from jax.core import Tracer
+
+
+def enforce_types(**types):
+    """Decorator that enforces given argument types at runtime.
+
+    Throws a TypeError if an invalid type is passed.
+
+    Example:
+
+        >>> @enforce_types(
+        ...     foo=(int, type(None)),
+        ...     bar=str
+        ... )
+        ... def func(x, foo, bar):
+        ...     print(bar)
+
+        >>> func(1, 2, 'hi there!')
+        hi there!
+
+        >>> func(1, 2, 3)
+        TypeError: func got unexpected type for argument "bar" (expected: str, got: <class 'int'>)
+
+    """
+
+    def decorator(function):
+        func_name = function.__name__
+        func_sig = inspect.signature(function)
+
+        for t in types:
+            # make sure given types are actually parameters of decorated function
+            if t not in func_sig.parameters:
+                raise ValueError(
+                    f"enforce_types decorator for {func_name} got unexpected argument {t}"
+                )
+
+            # make sure types are iterable
+            if not isinstance(types[t], (tuple, list)):
+                types[t] = (types[t],)
+
+        @functools.wraps(function)
+        def wrapped(*args, **kwargs):
+            # parse passed args
+            bound_args = func_sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+
+            # check one by one
+            for arg, val in bound_args.arguments.items():
+                if arg not in types:
+                    continue
+
+                arg_types = types[arg]
+
+                if not isinstance(val, arg_types):
+                    readable_arg_types = [t.__qualname__ for t in arg_types]
+                    if len(readable_arg_types) == 1:
+                        readable_arg_types = readable_arg_types[0]
+
+                    extra_message = ""
+                    if isinstance(val, Tracer):
+                        extra_message = (
+                            "\n\nAn abstract tracer was passed where a concrete value is expected. "
+                            "Try using the static_argnums argument of jax.jit."
+                        )
+
+                    raise TypeError(
+                        f'{func_name} got unexpected type for argument "{arg}" '
+                        f"(expected: {readable_arg_types}, got: {type(val)})."
+                        f"{extra_message}"
+                    )
+
+            return function(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/mpi4jax/validation.py
+++ b/mpi4jax/validation.py
@@ -34,7 +34,7 @@ def enforce_types(**types):
             # make sure given types are actually parameters of decorated function
             if t not in func_sig.parameters:
                 raise ValueError(
-                    f"enforce_types decorator for {func_name} got unexpected argument {t}"
+                    f'enforce_types decorator for {func_name} got unexpected argument "{t}"'
                 )
 
             # make sure types are iterable

--- a/tests/test_collective_ops.py
+++ b/tests/test_collective_ops.py
@@ -75,7 +75,6 @@ def test_allreduce_grad():
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
-    token = jax.lax.create_token(arr)
     res, grad = jax.value_and_grad(lambda x: Allreduce(x, op=MPI.SUM)[0].sum())(arr)
     assert jnp.array_equal(res, arr.sum() * size)
     assert jnp.array_equal(_arr, arr)

--- a/tests/test_collective_ops.py
+++ b/tests/test_collective_ops.py
@@ -87,7 +87,7 @@ def test_allreduce_grad():
 
     def testfun(x):
         y, token = Allreduce(x, op=MPI.SUM)
-        z = x + 2 * y
+        z = x + 2 * y  # noqa: F841
         res, token2 = Allreduce(x, op=MPI.SUM, token=token)
         return res.sum()
 
@@ -96,6 +96,7 @@ def test_allreduce_grad():
     assert jnp.array_equal(_arr, arr)
 
 
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test send/recv")
 def test_send_recv():
     from mpi4jax import Send, Recv
 
@@ -112,6 +113,7 @@ def test_send_recv():
         assert jnp.array_equal(_arr, arr)
 
 
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test send/recv")
 def test_send_recv_scalar():
     from mpi4jax import Send, Recv
 
@@ -128,6 +130,7 @@ def test_send_recv_scalar():
         assert jnp.array_equal(_arr, arr)
 
 
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test send/recv")
 def test_send_recv_scalar_jit():
     from mpi4jax import Send, Recv
 
@@ -144,6 +147,7 @@ def test_send_recv_scalar_jit():
         assert jnp.array_equal(_arr, arr)
 
 
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test send/recv")
 def test_send_recv_jit():
     from mpi4jax import Send, Recv
 
@@ -182,7 +186,27 @@ def test_send_recv_deadlock():
     assert jnp.array_equal(arr, jnp.ones_like(arr) * (1 - rank))
 
 
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test send/recv")
 def test_send_recv_status():
+    from mpi4jax import Send, Recv
+
+    arr = jnp.ones((3, 2)) * rank
+    _arr = arr.copy()
+
+    if rank == 0:
+        for proc in range(1, size):
+            status = MPI.Status()
+            res, token = Recv(arr, source=proc, tag=proc, status=status)
+            assert jnp.array_equal(res, jnp.ones_like(arr) * proc)
+            assert jnp.array_equal(_arr, arr)
+            assert status.Get_source() == proc
+    else:
+        Send(arr, 0, tag=rank)
+        assert jnp.array_equal(_arr, arr)
+
+
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test send/recv")
+def test_send_recv_status_jit():
     from mpi4jax import Send, Recv
 
     arr = jnp.ones((3, 2)) * rank
@@ -215,6 +239,42 @@ def test_sendrecv():
 
     assert jnp.array_equal(res, jnp.ones_like(arr) * other)
     assert jnp.array_equal(_arr, arr)
+
+
+@pytest.mark.skipif(size < 2 or rank > 1, reason="Runs only on rank 0 and 1")
+def test_sendrecv_status():
+    from mpi4jax import Sendrecv
+
+    arr = jnp.ones((3, 2)) * rank
+    _arr = arr.copy()
+
+    other = 1 - rank
+
+    status = MPI.Status()
+    res, token = Sendrecv(arr, arr, source=other, dest=other, status=status)
+
+    assert jnp.array_equal(res, jnp.ones_like(arr) * other)
+    assert jnp.array_equal(_arr, arr)
+    assert status.Get_source() == other
+
+
+@pytest.mark.skipif(size < 2 or rank > 1, reason="Runs only on rank 0 and 1")
+def test_sendrecv_status_jit():
+    from mpi4jax import Sendrecv
+
+    arr = jnp.ones((3, 2)) * rank
+    _arr = arr.copy()
+
+    other = 1 - rank
+
+    status = MPI.Status()
+    res, token = jax.jit(
+        lambda x, y: Sendrecv(x, y, source=other, dest=other, status=status)
+    )(arr, arr)
+
+    assert jnp.array_equal(res, jnp.ones_like(arr) * other)
+    assert jnp.array_equal(_arr, arr)
+    assert status.Get_source() == other
 
 
 @pytest.mark.skipif(size < 2 or rank > 1, reason="Runs only on rank 0 and 1")
@@ -274,14 +334,16 @@ def run_in_subprocess(code, test_file, timeout=10):
     from textwrap import dedent
 
     # this enables us to measure coverage in subprocesses
-    cov_preamble = dedent("""
+    cov_preamble = dedent(
+        """
     try:
         import coverage
         coverage.process_startup()
     except ImportError:
         pass
 
-    """)
+    """
+    )
 
     test_file.write_text(cov_preamble + code)
 
@@ -294,10 +356,7 @@ def run_in_subprocess(code, test_file, timeout=10):
         universal_newlines=True,
         # passing a mostly empty env seems to be the only way to
         # force MPI to initialize again
-        env=dict(
-            PATH=os.environ["PATH"],
-            COVERAGE_PROCESS_START="pyproject.toml",
-        ),
+        env=dict(PATH=os.environ["PATH"], COVERAGE_PROCESS_START="pyproject.toml",),
     )
     return proc
 

--- a/tests/test_flush.py
+++ b/tests/test_flush.py
@@ -1,4 +1,5 @@
 def test_flush():
     # all we can do is make sure this doesn't throw an exception
     from mpi4jax.flush import flush
+
     flush()

--- a/tests/test_flush.py
+++ b/tests/test_flush.py
@@ -1,0 +1,4 @@
+def test_flush():
+    # all we can do is make sure this doesn't throw an exception
+    from mpi4jax.flush import flush
+    flush()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,55 @@
+import pytest
+
+
+def test_enforce_types():
+    from types import FunctionType
+    from mpi4jax.validation import enforce_types
+
+    @enforce_types(y=(int, str), z=FunctionType)
+    def foo(x, y, z):
+        pass
+
+    # ok
+    foo(1, 2, lambda x: x)
+    foo("test", "test", lambda x: x)
+
+    # not ok
+    with pytest.raises(TypeError) as exc:
+        foo(1, lambda x: x, lambda x: x)
+
+    assert "expected: ['int', 'str'], got: <class 'function'>" in str(exc.value)
+
+    with pytest.raises(TypeError) as exc:
+        foo(1, 2, 3)
+
+    assert "expected: function, got: <class 'int'>" in str(exc.value)
+
+
+def test_enforce_types_invalid_args():
+    from mpi4jax.validation import enforce_types
+
+    def foo(x):
+        pass
+
+    with pytest.raises(ValueError) as exc:
+        enforce_types(a=int)(foo)
+
+    assert 'got unexpected argument "a"' in str(exc.value)
+
+
+def test_enforce_types_tracer():
+    import jax
+    from mpi4jax.validation import enforce_types
+
+    @enforce_types(x=int)
+    def foo(x):
+        pass
+
+    # ok
+    jax.jit(foo, static_argnums=(0,))(0)
+
+    # not ok
+    with pytest.raises(TypeError) as exc:
+        jax.jit(foo)(0)
+
+    assert "abstract tracer was passed" in str(exc.value)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -25,6 +25,32 @@ def test_enforce_types():
     assert "expected: function, got: <class 'int'>" in str(exc.value)
 
 
+def test_enforce_types_generic():
+    import numpy as np
+    from mpi4jax.validation import enforce_types
+
+    @enforce_types(x=np.integer)
+    def foo(x):
+        pass
+
+    # ok
+    foo(1)
+    foo(np.uint64(1))
+    foo(np.int(1))
+
+    # not ok
+    with pytest.raises(TypeError) as exc:
+        foo(True)
+
+    assert "expected: integer, got: <class 'bool'>" in str(
+        exc.value)
+
+    with pytest.raises(TypeError) as exc:
+        foo(1.2)
+
+    assert "expected: integer, got: <class 'float'>" in str(exc.value)
+
+
 def test_enforce_types_invalid_args():
     from mpi4jax.validation import enforce_types
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -42,8 +42,7 @@ def test_enforce_types_generic():
     with pytest.raises(TypeError) as exc:
         foo(True)
 
-    assert "expected: integer, got: <class 'bool'>" in str(
-        exc.value)
+    assert "expected: integer, got: <class 'bool'>" in str(exc.value)
 
     with pytest.raises(TypeError) as exc:
         foo(1.2)


### PR DESCRIPTION
Fixes #20.

With this, the example from #20 gives:

```python
>>> jax.jit(mpi4jax.Send)(jnp.ones(10), 1)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/dion/codes/mpi4jax/mpi4jax/validation.py", line 70, in wrapped
    f'{func_name} got unexpected type for argument "{arg}" '
jax.traceback_util.FilteredStackTrace: TypeError: Send got unexpected type for argument "dest" (expected: int, got: <class 'jax.interpreters.partial_eval.JaxprTracer'>).

An abstract tracer was passed where a concrete value is expected. Try using the static_argnums argument of jax.jit.

The stack trace above excludes JAX-internal frames.
The following is the original exception that occurred, unmodified.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/traceback_util.py", line 136, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/api.py", line 214, in f_jitted
    donated_invars=donated_invars)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/core.py", line 1146, in bind
    return call_bind(self, fun, *args, **params)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/core.py", line 1135, in call_bind
    outs = primitive.impl(fun, *args, **params)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/interpreters/xla.py", line 530, in _xla_call_impl
    *unsafe_map(arg_spec, args))
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/linear_util.py", line 224, in memoized_fun
    ans = call(fun, *args)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/interpreters/xla.py", line 601, in _xla_callable
    fun, pvals, instantiate=False, stage_out=True, bottom=True)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/interpreters/partial_eval.py", line 422, in trace_to_jaxpr
    jaxpr, (out_pvals, consts, env) = fun.call_wrapped(pvals)
  File "/Users/dion/.virtualenvs/science/lib/python3.7/site-packages/jax/linear_util.py", line 150, in call_wrapped
    ans = self.f(*args, **dict(self.params, **kwargs))
  File "/Users/dion/codes/mpi4jax/mpi4jax/validation.py", line 70, in wrapped
    f'{func_name} got unexpected type for argument "{arg}" '
TypeError: Send got unexpected type for argument "dest" (expected: int, got: <class 'jax.interpreters.partial_eval.JaxprTracer'>).

An abstract tracer was passed where a concrete value is expected. Try using the static_argnums argument of jax.jit.
```

This works by introducing a decorator `enforce_types` that works like this:

```python
>>> @enforce_types(
...     foo=(int, type(None)),
...     bar=str
... )
... def func(x, foo, bar):
...     print(bar)

>>> func(1, 2, 'hi there!')
hi there!

>>> func(1, 2, 3)
TypeError: func got unexpected type for argument "bar" (expected: str, got: <class 'int'>)
```

Since we are passing these objects as raw pointers to C it felt appropriate to be a bit stricter with types than usual.

This also means that something like this throws an error:

```python
>>> func(1, np.uint64(2), 'hi there!')
TypeError: func got unexpected type for argument "foo" (expected: ['int', 'NoneType'], got: <class 'numpy.uint64'>).
```

which is acceptable collateral damage IMO.
