### PR TITLE
GPU support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+_version.py

--- a/mpi4jax/cython/__init__.py
+++ b/mpi4jax/cython/__init__.py
@@ -1,14 +1,58 @@
 import os
+import warnings
 
 from jax.lib import xla_client
 
 from . import mpi_xla_bridge
+from . import mpi_xla_bridge_cpu
 
-mpi_xla_bridge.set_logging(
-    os.environ.get("MPI4JAX_DEBUG", "").lower() in ("true", "1", "on")
-)
+try:
+    from . import mpi_xla_bridge_gpu
+except ImportError:
+    HAS_GPU_EXT = False
+else:
+    HAS_GPU_EXT = True
 
-for name, fn in mpi_xla_bridge.cpu_custom_call_targets.items():
-    xla_client.register_cpu_custom_call_target(name, fn)
+
+def is_truthy(str_val):
+    return str_val.lower() in ("true", "1", "on")
+
+
+def is_falsy(str_val):
+    return str_val.lower() in ("false", "0", "off")
+
+
+enable_logging = is_truthy(os.environ.get("MPI4JAX_DEBUG", ""))
+mpi_xla_bridge.set_logging(enable_logging)
+
+
+if HAS_GPU_EXT:
+    gpu_copy_behavior = os.environ.get("MPI4JAX_USE_CUDA_MPI", "")
+
+    if is_truthy(gpu_copy_behavior):
+        has_cuda_mpi = True
+    elif is_falsy(gpu_copy_behavior):
+        has_cuda_mpi = False
+    else:
+        has_cuda_mpi = False
+        warn_msg = (
+            "Not using CUDA-enabled MPI. "
+            "If you are sure that your MPI library is built with CUDA support, "
+            "set MPI4JAX_USE_CUDA_MPI=1. To silence this warning, "
+            "set MPI4JAX_USE_CUDA_MPI=0."
+        )
+        warnings.warn(warn_msg)
+
+    mpi_xla_bridge_gpu.set_copy_to_host(not has_cuda_mpi)
+
+
+# register custom call targets
+for name, fn in mpi_xla_bridge_cpu.cpu_custom_call_targets.items():
+    xla_client.register_custom_call_target(name, fn, platform="cpu")
+
+if HAS_GPU_EXT:
+    for name, fn in mpi_xla_bridge_gpu.gpu_custom_call_targets.items():
+        xla_client.register_custom_call_target(name, fn, platform="gpu")
+
 
 del os, xla_client

--- a/mpi4jax/cython/cuda_runtime_api.pxd
+++ b/mpi4jax/cython/cuda_runtime_api.pxd
@@ -1,15 +1,18 @@
 cdef extern from "cuda_runtime_api.h":
     cdef enum cudaError:
-        cudaSuccess
+        cudaSuccess = 0
 
     cdef enum cudaMemcpyKind:
-        cudaMemcpyHostToHost
-        cudaMemcpyHostToDevice
-        cudaMemcpyDeviceToHost
-        cudaMemcpyDeviceToDevice
-        cudaMemcpyDefault
+        cudaMemcpyHostToHost = 0
+        cudaMemcpyHostToDevice = 1
+        cudaMemcpyDeviceToHost = 2
+        cudaMemcpyDeviceToDevice = 3
+        cudaMemcpyDefault = 4
 
     ctypedef cudaError cudaError_t
 
     ctypedef void* cudaStream_t
     cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, cudaMemcpyKind kind) nogil
+
+    char* cudaGetErrorName(cudaError_t error) nogil
+    char* cudaGetErrorString(cudaError_t error) nogil

--- a/mpi4jax/cython/cuda_runtime_api.pxd
+++ b/mpi4jax/cython/cuda_runtime_api.pxd
@@ -1,0 +1,15 @@
+cdef extern from "cuda_runtime_api.h":
+    cdef enum cudaError:
+        cudaSuccess
+
+    cdef enum cudaMemcpyKind:
+        cudaMemcpyHostToHost
+        cudaMemcpyHostToDevice
+        cudaMemcpyDeviceToHost
+        cudaMemcpyDeviceToDevice
+        cudaMemcpyDefault
+
+    ctypedef cudaError cudaError_t
+
+    ctypedef void* cudaStream_t
+    cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, cudaMemcpyKind kind) nogil

--- a/mpi4jax/cython/mpi_xla_bridge.pxd
+++ b/mpi4jax/cython/mpi_xla_bridge.pxd
@@ -1,0 +1,17 @@
+from libc.stdint cimport int32_t, uint64_t
+from mpi4py.libmpi cimport MPI_Comm, MPI_Datatype, MPI_Status, MPI_Op
+
+cdef int abort_on_error(int ierr, MPI_Comm comm, unicode mpi_op) nogil
+
+cdef void mpi_send(void* sendbuf, int32_t nitems, MPI_Datatype dtype,
+                   int32_t destination, int32_t tag, MPI_Comm comm, void* token) nogil
+
+cdef void mpi_recv(void* recvbuf, int32_t nitems, MPI_Datatype dtype, int32_t source,
+                   int32_t tag, MPI_Comm comm, MPI_Status* status, void* token) nogil
+
+cdef void mpi_sendrecv(void* sendbuf, int32_t sendcount, MPI_Datatype sendtype, int32_t dest, int32_t sendtag,
+                       void* recvbuf, int32_t recvcount, MPI_Datatype recvtype, int32_t source, int32_t recvtag,
+                       MPI_Comm comm, MPI_Status* status, void* token) nogil
+
+cdef void mpi_allreduce(void* sendbuf, void* recvbuf, int32_t nitems,
+                        MPI_Datatype dtype, MPI_Op op, MPI_Comm comm, void* token) nogil

--- a/mpi4jax/cython/mpi_xla_bridge.pyx
+++ b/mpi4jax/cython/mpi_xla_bridge.pyx
@@ -1,12 +1,7 @@
-# cython: language_level=3
-
 import sys
 
-from cpython.pycapsule cimport PyCapsule_New
+from libc.stdint cimport int32_t, uint64_t
 
-from libc.stdint cimport int32_t, int64_t, uint64_t
-
-cimport mpi4py.MPI as MPI
 cimport mpi4py.libmpi as libmpi
 from mpi4py.libmpi cimport (
     MPI_Comm,
@@ -16,14 +11,33 @@ from mpi4py.libmpi cimport (
     MPI_STATUS_IGNORE,
     MPI_SUCCESS,
     MPI_Comm_rank,
+    MPI_Abort,
 )
-
 
 # MPI_STATUS_IGNORE is not exposed to Python by mpi4py, so we
 # export its memory address as Python int here.
 # This can then be passed to all functions that expect
 # MPI_Status* instead of a pointer to a real status object.
 MPI_STATUS_IGNORE_ADDR = int(<uint64_t>MPI_STATUS_IGNORE)
+
+
+#
+# Logging
+#
+
+cdef bint PRINT_DEBUG = False
+
+
+cpdef void set_logging(bint enable):
+    global PRINT_DEBUG
+    PRINT_DEBUG = enable
+
+
+cdef inline void print_debug(unicode message, MPI_Comm comm) nogil:
+    cdef int rank
+    MPI_Comm_rank(comm, &rank)
+    with gil:
+        print(f"r{rank} | {message}")
 
 
 #
@@ -42,138 +56,66 @@ cdef inline int abort_on_error(int ierr, MPI_Comm comm, unicode mpi_op) nogil:
             f'r{rank} | MPI_{mpi_op} returned error code {ierr} - aborting\n'
         )
         sys.stderr.flush()
-        return libmpi.MPI_Abort(comm, ierr)
+        return MPI_Abort(comm, ierr)
 
 
 #
-# Logging
+# Wrapped MPI primitives
 #
 
-cdef bint PRINT_DEBUG = False
-
-cpdef void set_logging(bint enable):
-    global PRINT_DEBUG
-    PRINT_DEBUG = enable
-
-
-#
-# Custom XLA targets (MPI primitives)
-#
-
-cdef void mpi_send(void** out_ptr, void** data_ptr) nogil:
-    cdef int rank, ierr
-
-    #decode inputs
-    cdef int32_t nitems = (<int32_t*>(data_ptr[0]))[0]
-    cdef int32_t destination = (<int32_t*>(data_ptr[2]))[0]
-    cdef int32_t tag = (<int32_t*>(data_ptr[3]))[0]
-    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[4]))[0])
-    cdef MPI_Datatype dtype = <MPI_Datatype>((<uint64_t*>(data_ptr[5]))[0])
-    cdef void* token = data_ptr[6]
-
+cdef void mpi_send(void* sendbuf, int32_t nitems, MPI_Datatype dtype,
+                   int32_t destination, int32_t tag, MPI_Comm comm, void* token) nogil:
     if PRINT_DEBUG:
-        MPI_Comm_rank(comm, &rank)
         with gil:
-            print(f"r{rank} | MPI_Send -> {destination} with tag {tag} and token {<uint64_t>token:x}")
+            print_debug(f"MPI_Send -> {destination} with tag {tag} and token {<uint64_t>token:x}", comm)
 
     # MPI Call
-    ierr = libmpi.MPI_Send(data_ptr[1], nitems, dtype, destination, tag, comm)
+    cdef int ierr
+    ierr = libmpi.MPI_Send(sendbuf, nitems, dtype, destination, tag, comm)
     abort_on_error(ierr, comm, u"Send")
 
-    out_ptr[0] = token
 
-
-cdef void mpi_recv(void** out_ptr, void** data_ptr) nogil:
-    cdef int rank, ierr
-
-    #decode inputs
-    cdef int32_t nitems = (<int32_t*>(data_ptr[0]))[0]
-    cdef int32_t source = (<int32_t*>(data_ptr[1]))[0]
-    cdef int32_t tag = (<int32_t*>(data_ptr[2]))[0]
-    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[3]))[0])
-    cdef MPI_Datatype dtype = <MPI_Datatype>((<uint64_t*>(data_ptr[4]))[0])
-    cdef MPI_Status* status = <MPI_Status*>((<uint64_t*>(data_ptr[5]))[0])
-    cdef void* token = data_ptr[6]
-
+cdef void mpi_recv(void* recvbuf, int32_t nitems, MPI_Datatype dtype, int32_t source,
+                   int32_t tag, MPI_Comm comm, MPI_Status* status, void* token) nogil:
     if PRINT_DEBUG:
-        MPI_Comm_rank(comm, &rank)
         with gil:
-            print(f"r{rank} | MPI_Recv <- {source} with tag {tag} and token {<uint64_t> token:x}")
+            print_debug(f"MPI_Recv <- {source} with tag {tag} and token {<uint64_t> token:x}", comm)
 
     # MPI Call
-    ierr = libmpi.MPI_Recv(out_ptr[0], nitems, dtype, source, tag, comm, status)
+    cdef int ierr
+    ierr = libmpi.MPI_Recv(recvbuf, nitems, dtype, source, tag, comm, status)
     abort_on_error(ierr, comm, u"Recv")
 
-    out_ptr[1] = token
 
-
-cdef void mpi_sendrecv(void** out_ptr, void** data_ptr) nogil:
-    cdef int rank
-
-    #decode inputs
-    cdef int32_t sendcount = (<int32_t*>(data_ptr[0]))[0]
-    cdef int32_t dest = (<int32_t*>(data_ptr[2]))[0]
-    cdef int32_t sendtag = (<int32_t*>(data_ptr[3]))[0]
-    cdef MPI_Datatype sendtype = <MPI_Datatype>((<uint64_t*>(data_ptr[4]))[0])
-
-    cdef int32_t recvcount = (<int32_t*>(data_ptr[5]))[0]
-    cdef int32_t source = (<int32_t*>(data_ptr[6]))[0]
-    cdef int32_t recvtag = (<int32_t*>(data_ptr[7]))[0]
-    cdef MPI_Datatype recvtype = <MPI_Datatype>((<uint64_t*>(data_ptr[8]))[0])
-
-    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[9]))[0])
-    cdef MPI_Status* status = <MPI_Status*>((<uint64_t*>(data_ptr[10]))[0])
-
-    cdef void* token = data_ptr[11]
+cdef void mpi_sendrecv(void* sendbuf, int32_t sendcount, MPI_Datatype sendtype, int32_t dest, int32_t sendtag,
+                       void* recvbuf, int32_t recvcount, MPI_Datatype recvtype, int32_t source, int32_t recvtag,
+                       MPI_Comm comm, MPI_Status* status, void* token) nogil:
+    cdef int ierr
 
     if PRINT_DEBUG:
-        MPI_Comm_rank(comm, &rank)
         with gil:
-            print(
-                f"r{rank} | MPI_Sendrecv <- {source} (tag {recvtag}) / -> {dest} (tag {sendtag}) "
-                f"with token {<uint64_t>token:x}"
+            print_debug(
+                f"MPI_Sendrecv <- {source} (tag {recvtag}) / -> {dest} (tag {sendtag}) "
+                f"with token {<uint64_t>token:x}", comm
             )
 
     # MPI Call
     ierr = libmpi.MPI_Sendrecv(
-        data_ptr[1], sendcount, sendtype, dest, sendtag,
-        out_ptr[0], recvcount, recvtype, source, recvtag,
+        sendbuf, sendcount, sendtype, dest, sendtag,
+        recvbuf, recvcount, recvtype, source, recvtag,
         comm, status
     )
     abort_on_error(ierr, comm, u"Sendrecv")
 
-    out_ptr[1] = token
 
-
-cdef void mpi_allreduce(void** out_ptr, void** data_ptr) nogil:
-    cdef int rank, ierr
-
-    #decode inputs
-    cdef int32_t nitems = (<int32_t*>(data_ptr[0]))[0]
-    cdef MPI_Op op = <MPI_Op>((<uint64_t*>(data_ptr[2]))[0])
-    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[3]))[0])
-    cdef MPI_Datatype dtype = <MPI_Datatype>((<uint64_t*>(data_ptr[4]))[0])
-    cdef void* token = data_ptr[5]
+cdef void mpi_allreduce(void* sendbuf, void* recvbuf, int32_t nitems,
+                        MPI_Datatype dtype, MPI_Op op, MPI_Comm comm, void* token) nogil:
+    cdef int ierr
 
     if PRINT_DEBUG:
-        MPI_Comm_rank(comm, &rank)
         with gil:
-            print(f"r{rank} | MPI_Allreduce with token {<uint64_t>token:x}")
+            print_debug(f"MPI_Allreduce with token {<uint64_t>token:x}", comm)
 
     # MPI Call
-    ierr = libmpi.MPI_Allreduce(data_ptr[1], out_ptr[0], nitems, dtype, op, comm)
+    ierr = libmpi.MPI_Allreduce(sendbuf, recvbuf, nitems, dtype, op, comm)
     abort_on_error(ierr, comm, u"Allreduce")
-
-    out_ptr[1] = token
-
-
-cpu_custom_call_targets = {}
-
-cdef register_custom_call_target(fn_name, void* fn):
-    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
-    cpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
-
-register_custom_call_target(b"mpi_send", <void*>(mpi_send))
-register_custom_call_target(b"mpi_recv", <void*>(mpi_recv))
-register_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv))
-register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce))

--- a/mpi4jax/cython/mpi_xla_bridge_cpu.pyx
+++ b/mpi4jax/cython/mpi_xla_bridge_cpu.pyx
@@ -1,0 +1,96 @@
+from cpython.pycapsule cimport PyCapsule_New
+
+from libc.stdint cimport int32_t, uint64_t
+
+from mpi4py.libmpi cimport (
+    MPI_Comm,
+    MPI_Datatype,
+    MPI_Op,
+    MPI_Status
+)
+
+from . cimport mpi_xla_bridge
+
+
+#
+# CPU XLA targets
+#
+
+cdef void mpi_send_cpu(void** out_ptr, void** data_ptr) nogil:
+    cdef int32_t nitems = (<int32_t*>(data_ptr[0]))[0]
+    cdef void* sendbuf = data_ptr[1]
+    cdef int32_t destination = (<int32_t*>(data_ptr[2]))[0]
+    cdef int32_t tag = (<int32_t*>(data_ptr[3]))[0]
+    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[4]))[0])
+    cdef MPI_Datatype dtype = <MPI_Datatype>((<uint64_t*>(data_ptr[5]))[0])
+    cdef void* token = data_ptr[6]
+
+    mpi_xla_bridge.mpi_send(sendbuf, nitems, dtype, destination, tag, comm, token)
+    out_ptr[0] = token
+
+
+cdef void mpi_recv_cpu(void** out_ptr, void** data_ptr) nogil:
+    cdef int32_t nitems = (<int32_t*>(data_ptr[0]))[0]
+    cdef int32_t source = (<int32_t*>(data_ptr[1]))[0]
+    cdef int32_t tag = (<int32_t*>(data_ptr[2]))[0]
+    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[3]))[0])
+    cdef MPI_Datatype dtype = <MPI_Datatype>((<uint64_t*>(data_ptr[4]))[0])
+    cdef MPI_Status* status = <MPI_Status*>((<uint64_t*>(data_ptr[5]))[0])
+    cdef void* token = data_ptr[6]
+
+    cdef void* recvbuf = out_ptr[0]
+    mpi_xla_bridge.mpi_recv(recvbuf, nitems, dtype, source, tag, comm, status, token)
+    out_ptr[1] = token
+
+
+cdef void mpi_sendrecv_cpu(void** out_ptr, void** data_ptr) nogil:
+    cdef int32_t sendcount = (<int32_t*>(data_ptr[0]))[0]
+    cdef void* sendbuf = data_ptr[1]
+    cdef int32_t dest = (<int32_t*>(data_ptr[2]))[0]
+    cdef int32_t sendtag = (<int32_t*>(data_ptr[3]))[0]
+    cdef MPI_Datatype sendtype = <MPI_Datatype>((<uint64_t*>(data_ptr[4]))[0])
+
+    cdef int32_t recvcount = (<int32_t*>(data_ptr[5]))[0]
+    cdef int32_t source = (<int32_t*>(data_ptr[6]))[0]
+    cdef int32_t recvtag = (<int32_t*>(data_ptr[7]))[0]
+    cdef MPI_Datatype recvtype = <MPI_Datatype>((<uint64_t*>(data_ptr[8]))[0])
+
+    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[9]))[0])
+    cdef MPI_Status* status = <MPI_Status*>((<uint64_t*>(data_ptr[10]))[0])
+
+    cdef void* token = data_ptr[11]
+
+    cdef void* recvbuf = out_ptr[0]
+    mpi_xla_bridge.mpi_sendrecv(
+        sendbuf, sendcount, sendtype, dest, sendtag,
+        recvbuf, recvcount, recvtype, source, recvtag,
+        comm, status, token
+    )
+    out_ptr[1] = token
+
+
+cdef void mpi_allreduce_cpu(void** out_ptr, void** data_ptr) nogil:
+    cdef int32_t nitems = (<int32_t*>(data_ptr[0]))[0]
+    cdef void* sendbuf = data_ptr[1]
+    cdef MPI_Op op = <MPI_Op>((<uint64_t*>(data_ptr[2]))[0])
+    cdef MPI_Comm comm = <MPI_Comm>((<uint64_t*>(data_ptr[3]))[0])
+    cdef MPI_Datatype dtype = <MPI_Datatype>((<uint64_t*>(data_ptr[4]))[0])
+    cdef void* token = data_ptr[5]
+
+    cdef void* recvbuf = out_ptr[0]
+    mpi_xla_bridge.mpi_allreduce(
+        sendbuf, recvbuf, nitems, dtype, op, comm, token
+    )
+    out_ptr[1] = token
+
+
+cpu_custom_call_targets = {}
+
+cdef register_custom_call_target(fn_name, void* fn):
+    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
+    cpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
+
+register_custom_call_target(b"mpi_send", <void*>(mpi_send_cpu))
+register_custom_call_target(b"mpi_recv", <void*>(mpi_recv_cpu))
+register_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv_cpu))
+register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_cpu))

--- a/mpi4jax/cython/mpi_xla_bridge_gpu.pyx
+++ b/mpi4jax/cython/mpi_xla_bridge_gpu.pyx
@@ -1,0 +1,326 @@
+from cpython.pycapsule cimport PyCapsule_New
+
+from libc.stdint cimport int32_t, uint64_t
+from libc.stdlib cimport malloc, free
+
+from mpi4py.libmpi cimport (
+    MPI_Comm,
+    MPI_Op,
+    MPI_Datatype,
+    MPI_Status,
+    MPI_Type_size
+)
+
+from .cuda_runtime_api cimport (
+    cudaMemcpy,
+    cudaMemcpyHostToDevice,
+    cudaMemcpyDeviceToHost,
+    cudaStream_t,
+    cudaError_t,
+    cudaMemcpyKind,
+    cudaSuccess,
+)
+
+from . cimport mpi_xla_bridge
+from .mpi_xla_bridge cimport abort_on_error
+
+
+cdef bint COPY_TO_HOST = False
+
+cpdef void set_copy_to_host(bint enable):
+    global COPY_TO_HOST
+    COPY_TO_HOST = enable
+
+
+cdef inline void* checked_malloc(size_t count) nogil except *:
+    cdef void* mem = malloc(count)
+    if not mem:
+        with gil:
+            raise MemoryError(f"Failed to allocate {count} bytes")
+
+    return mem
+
+
+cdef inline cudaError_t checked_cuda_memcpy(void* dst, void* src, size_t count, cudaMemcpyKind kind) nogil except *:
+    cdef cudaError_t ierr
+    ierr = cudaMemcpy(dst, src, count, kind)
+
+    if ierr != cudaSuccess:
+        with gil:
+            raise RuntimeError(f"cudaMemcpy failed with error code {ierr}")
+
+    return ierr
+
+
+#
+# GPU XLA targets
+#
+
+# Allreduce
+
+cdef struct AllreduceDescriptor:
+    int32_t nitems
+    MPI_Op op
+    MPI_Comm comm
+    MPI_Datatype dtype
+
+
+cpdef bytes build_allreduce_descriptor(int32_t nitems, uint64_t op_addr, uint64_t comm_addr, uint64_t dtype_addr):
+    cdef AllreduceDescriptor desc = AllreduceDescriptor(
+        nitems, <MPI_Op> op_addr, <MPI_Comm> comm_addr, <MPI_Datatype> dtype_addr
+    )
+    return bytes((<char*> &desc)[:sizeof(AllreduceDescriptor)])
+
+
+cdef void mpi_allreduce(cudaStream_t* stream, void** buffers,
+                        const char* opaque, size_t opaque_len) nogil except *:
+    cdef int ierr, dtype_size
+    cdef size_t count
+
+    #decode inputs
+    cdef void* data = buffers[0]
+    cdef void* token = buffers[1]
+    cdef void* out_data = buffers[2]
+
+    cdef void* in_buf = data
+    cdef void* out_buf = out_data
+
+    if opaque_len != sizeof(AllreduceDescriptor):
+        with gil:
+            raise RuntimeError("got wrong size of opaque argument")
+
+    cdef AllreduceDescriptor* desc = <AllreduceDescriptor*>(opaque)
+    cdef int32_t nitems = desc.nitems
+    cdef MPI_Op op = desc.op
+    cdef MPI_Comm comm = desc.comm
+    cdef MPI_Datatype dtype = desc.dtype
+
+    if COPY_TO_HOST:
+        # copy memory to host
+        ierr = MPI_Type_size(dtype, &dtype_size)
+        abort_on_error(ierr, comm, u"Type_size")
+
+        count = dtype_size * nitems
+        in_buf = checked_malloc(count)
+        out_buf = checked_malloc(count)
+        checked_cuda_memcpy(in_buf, data, count, cudaMemcpyDeviceToHost)
+
+    mpi_xla_bridge.mpi_allreduce(in_buf, out_buf, nitems, dtype, op, comm, token)
+
+    if COPY_TO_HOST:
+        # copy back to device
+        checked_cuda_memcpy(out_data, out_buf, count, cudaMemcpyHostToDevice)
+        free(in_buf)
+        free(out_buf)
+
+    buffers[3] = token
+
+
+# Send
+
+cdef struct SendDescriptor:
+    int32_t nitems
+    int32_t dest
+    int32_t tag
+    MPI_Comm comm
+    MPI_Datatype dtype
+
+
+cpdef bytes build_send_descriptor(int32_t nitems, int32_t dest, int32_t tag, uint64_t comm_addr, uint64_t dtype_addr):
+    cdef SendDescriptor desc = SendDescriptor(
+        nitems, dest, tag, <MPI_Comm> comm_addr, <MPI_Datatype> dtype_addr
+    )
+    return bytes((<char*> &desc)[:sizeof(SendDescriptor)])
+
+
+cdef void mpi_send(cudaStream_t* stream, void** buffers,
+                   const char* opaque, size_t opaque_len) nogil except *:
+    cdef int ierr, dtype_size
+    cdef size_t count
+
+    #decode inputs
+    cdef void* data = buffers[0]
+    cdef void* token = buffers[1]
+
+    cdef void* sendbuf = data
+
+    if opaque_len != sizeof(SendDescriptor):
+        with gil:
+            raise RuntimeError("got wrong size of opaque argument")
+
+    cdef SendDescriptor* desc = <SendDescriptor*>(opaque)
+    cdef int32_t nitems = desc.nitems
+    cdef int32_t dest = desc.dest
+    cdef int32_t tag = desc.tag
+    cdef MPI_Comm comm = desc.comm
+    cdef MPI_Datatype dtype = desc.dtype
+
+    if COPY_TO_HOST:
+        # copy memory to host
+        ierr = MPI_Type_size(dtype, &dtype_size)
+        abort_on_error(ierr, comm, u"Type_size")
+
+        count = dtype_size * nitems
+        sendbuf = checked_malloc(count)
+        checked_cuda_memcpy(sendbuf, data, count, cudaMemcpyDeviceToHost)
+
+    mpi_xla_bridge.mpi_send(sendbuf, nitems, dtype, dest, tag, comm, token)
+
+    if COPY_TO_HOST:
+        free(sendbuf)
+
+    buffers[2] = token
+
+
+# Recv
+
+cdef struct RecvDescriptor:
+    int32_t nitems
+    int32_t source
+    int32_t tag
+    MPI_Comm comm
+    MPI_Datatype dtype
+    MPI_Status* status
+
+
+cpdef bytes build_recv_descriptor(int32_t nitems, int32_t dest, int32_t tag, uint64_t comm_addr,
+                                  uint64_t dtype_addr, uint64_t status_addr):
+    cdef RecvDescriptor desc = RecvDescriptor(
+        nitems, dest, tag, <MPI_Comm> comm_addr, <MPI_Datatype> dtype_addr, <MPI_Status*> status_addr
+    )
+    return bytes((<char*> &desc)[:sizeof(RecvDescriptor)])
+
+
+cdef void mpi_recv(cudaStream_t* stream, void** buffers,
+                   const char* opaque, size_t opaque_len) nogil except *:
+    cdef int ierr, dtype_size
+    cdef size_t count
+
+    #decode inputs
+    cdef void* token = buffers[0]
+    cdef void* out_buf = buffers[1]
+
+    cdef void* recvbuf = out_buf
+
+    if opaque_len != sizeof(RecvDescriptor):
+        with gil:
+            raise RuntimeError("got wrong size of opaque argument")
+
+    cdef RecvDescriptor* desc = <RecvDescriptor*>(opaque)
+    cdef int32_t nitems = desc.nitems
+    cdef int32_t source = desc.source
+    cdef int32_t tag = desc.tag
+    cdef MPI_Comm comm = desc.comm
+    cdef MPI_Datatype dtype = desc.dtype
+    cdef MPI_Status* status = desc.status
+
+    if COPY_TO_HOST:
+        # copy memory to host
+        ierr = MPI_Type_size(dtype, &dtype_size)
+        abort_on_error(ierr, comm, u"Type_size")
+
+        count = dtype_size * nitems
+        recvbuf = checked_malloc(count)
+
+    mpi_xla_bridge.mpi_recv(recvbuf, nitems, dtype, source, tag, comm, status, token)
+
+    if COPY_TO_HOST:
+        checked_cuda_memcpy(out_buf, recvbuf, count, cudaMemcpyHostToDevice)
+        free(recvbuf)
+
+    buffers[2] = token
+
+
+# Sendrecv
+
+cdef struct SendrecvDescriptor:
+    int32_t sendcount
+    int32_t dest
+    int32_t sendtag
+    MPI_Datatype sendtype
+    int32_t recvcount
+    int32_t source
+    int32_t recvtag
+    MPI_Datatype recvtype
+    MPI_Comm comm
+    MPI_Status* status
+
+
+cpdef bytes build_sendrecv_descriptor(int32_t sendcount, int32_t dest, int32_t sendtag, uint64_t sendtype_addr,
+                                      int32_t recvcount, int32_t source, int32_t recvtag, uint64_t recvtype_addr,
+                                      uint64_t comm_addr, uint64_t status_addr):
+    cdef SendrecvDescriptor desc = SendrecvDescriptor(
+        sendcount, dest, sendtag, <MPI_Datatype> sendtype_addr,
+        recvcount, source, recvtag, <MPI_Datatype> recvtype_addr,
+        <MPI_Comm> comm_addr, <MPI_Status*> status_addr
+    )
+    return bytes((<char*> &desc)[:sizeof(SendrecvDescriptor)])
+
+
+cdef void mpi_sendrecv(cudaStream_t* stream, void** buffers,
+                       const char* opaque, size_t opaque_len) nogil except *:
+    cdef int ierr, send_dtype_size, recv_dtype_size
+    cdef size_t bytes_send, bytes_recv
+
+    #decode inputs
+    cdef void* in_buf = buffers[0]
+    cdef void* token = buffers[1]
+    cdef void* out_buf = buffers[2]
+
+    cdef void* sendbuf = in_buf
+    cdef void* recvbuf = out_buf
+
+    if opaque_len != sizeof(SendrecvDescriptor):
+        with gil:
+            raise RuntimeError("got wrong size of opaque argument")
+
+    cdef SendrecvDescriptor* desc = <SendrecvDescriptor*>(opaque)
+    cdef int32_t sendcount = desc.sendcount
+    cdef int32_t dest = desc.dest
+    cdef int32_t sendtag = desc.sendtag
+    cdef MPI_Datatype sendtype = desc.sendtype
+    cdef int32_t recvcount = desc.recvcount
+    cdef int32_t source = desc.source
+    cdef int32_t recvtag = desc.recvtag
+    cdef MPI_Datatype recvtype = desc.recvtype
+    cdef MPI_Comm comm = desc.comm
+    cdef MPI_Status* status = desc.status
+
+    if COPY_TO_HOST:
+        # copy memory to host
+        ierr = MPI_Type_size(sendtype, &send_dtype_size)
+        abort_on_error(ierr, comm, u"Type_size")
+
+        ierr = MPI_Type_size(recvtype, &recv_dtype_size)
+        abort_on_error(ierr, comm, u"Type_size")
+
+        bytes_send = send_dtype_size * sendcount
+        bytes_recv = recv_dtype_size * recvcount
+        sendbuf = checked_malloc(bytes_send)
+        recvbuf = checked_malloc(bytes_recv)
+        checked_cuda_memcpy(sendbuf, in_buf, bytes_send, cudaMemcpyDeviceToHost)
+
+    mpi_xla_bridge.mpi_sendrecv(
+        sendbuf, sendcount, sendtype, dest, sendtag,
+        recvbuf, recvcount, recvtype, source, recvtag,
+        comm, status, token
+    )
+
+    if COPY_TO_HOST:
+        checked_cuda_memcpy(out_buf, recvbuf, bytes_recv, cudaMemcpyHostToDevice)
+        free(recvbuf)
+
+    buffers[3] = token
+
+
+gpu_custom_call_targets = {}
+
+cdef register_custom_call_target(fn_name, void* fn):
+    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
+    gpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
+
+
+register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce))
+register_custom_call_target(b"mpi_send", <void*>(mpi_send))
+register_custom_call_target(b"mpi_recv", <void*>(mpi_recv))
+register_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv))

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,32 @@ else:
     HAS_CYTHON = True
 
 
+#######
+# Utils
+def search_on_path(filenames):
+    for p in get_path("PATH"):
+        for filename in filenames:
+            full = os.path.join(p, filename)
+            if os.path.exists(full):
+                return os.path.abspath(full)
+    return None
+
+
+def print_warning(*lines):
+    print("**************************************************")
+    for line in lines:
+        print("*** WARNING: %s" % line)
+    print("**************************************************")
+
+
+def get_path(key):
+    return os.environ.get(key, "").split(os.pathsep)
+
+
+# /end Utils
+############
+
+
 def mpi_info(cmd):
     import mpi4py
 
@@ -34,27 +60,68 @@ def mpi_info(cmd):
     return out
 
 
+################
+# Cuda detection
+
+# Taken from CUPY (MIT License)
+def get_cuda_path():
+    nvcc_path = search_on_path(("nvcc", "nvcc.exe"))
+    cuda_path_default = None
+    if nvcc_path is not None:
+        cuda_path_default = os.path.normpath(
+            os.path.join(os.path.dirname(nvcc_path), "..")
+        )
+
+    cuda_path = os.environ.get("CUDA_PATH", "")  # Nvidia default on Windows
+    if len(cuda_path) == 0:
+        cuda_path = os.environ.get("CUDA_ROOT", "")  # Nvidia default on Windows
+
+    if len(cuda_path) > 0 and cuda_path != cuda_path_default:
+        print_warning(
+            "nvcc path != CUDA_PATH",
+            "nvcc path: %s" % cuda_path_default,
+            "CUDA_PATH: %s" % cuda_path,
+        )
+
+    if os.path.exists(cuda_path):
+        _cuda_path = cuda_path
+    elif cuda_path_default is not None:
+        _cuda_path = cuda_path_default
+    elif os.path.exists("/usr/local/cuda"):
+        _cuda_path = "/usr/local/cuda"
+    else:
+        _cuda_path = None
+
+    return _cuda_path
+
+
 def cuda_info(cmd):
-    # TODO: replace with more robust way to find CUDA toolkit
-    cuda_root = os.environ.get("CUDA_ROOT")
-    if not cuda_root:
+    cuda_path = get_cuda_path()
+    if not cuda_path:
         return []
 
     if cmd == "compile":
-        incdir = os.path.join(cuda_root, "include")
+        incdir = os.path.join(cuda_path, "include")
         if os.path.isdir(incdir):
             return [incdir]
 
     if cmd == "libdirs":
-        libdir = os.path.join(cuda_root, "lib64")
+        libdir = os.path.join(cuda_path, "lib64")
         if os.path.isdir(libdir):
             return [libdir]
+        else:
+            libdir = os.path.join(cuda_path, "lib")
+            if os.path.isdir(libdir):
+                return [libdir]
 
     if cmd == "libs":
         return ["cudart"]
 
     return []
 
+
+# /end Cuda detection
+#####################
 
 if HAS_CYTHON:
     CY_EXT = "pyx"
@@ -125,5 +192,5 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=["jax", "jaxlib>=0.1.55", "mpi4py>=3.0.1", "numpy"],
-    extras_require={"dev": ["pytest"]},
+    extras_require={"dev": ["pytest", "black", "flake8==3.8.3", "pre-commit>=2"]},
 )


### PR DESCRIPTION
Very much work in progress. Fixes #6.

### To do

- [x] Implement GPU version of one primitive
- [x] Implement fallback through host memory for one primitive
- [ ] Check whether we need to synchronize the CUDA stream in primitives
- [x] Make sure implementation is portable across platforms
- [ ] Make sure implementation is portable across CUDA and MPI versions
- [x] Implement GPU versions of other primitives
- [x] Make GPU primitives optional (`mpi4jax` should be usable without CUDA)
- [x] More robust way to find CUDA runtime library in `setup.py`
- [ ] ~Detect whether CUDA support is available through MPI and switch to fallback implementation if not~
- [x] Warn when falling back to communication through host
- [x] Check for CUDA errors
- [x] Tests