### PR TITLE
Test the transpose of allreduce with jit

### DIFF
--- a/tests/test_allreduce_matvec.py
+++ b/tests/test_allreduce_matvec.py
@@ -49,8 +49,6 @@ A_local = A[:, start_local:end_local]
 x_local = x[start_local:end_local]
 v_local = v[start_local:end_local]
 
-test_token = jax.lax.create_token(123)
-
 
 # expected results:
 Ax = A @ x
@@ -61,15 +59,13 @@ ATvprime_local = (A.T @ vprime)[start_local:end_local]
 
 
 def allreduce_sum(x):
-    res, token = Allreduce(x, op=MPI.SUM, comm=MPI.COMM_WORLD, token=test_token)
+    res, token = Allreduce(x, op=MPI.SUM, comm=MPI.COMM_WORLD)
     return res
 
 
 # this is just an identity
 def allreduce_sumT(y):
-    res, token = Allreduce(
-        y, op=MPI.SUM, comm=MPI.COMM_WORLD, token=test_token, _transpose=True
-    )
+    res, token = Allreduce(y, op=MPI.SUM, comm=MPI.COMM_WORLD, _transpose=True)
     return res
 
 

--- a/tests/test_allreduce_matvec.py
+++ b/tests/test_allreduce_matvec.py
@@ -106,8 +106,18 @@ def test_matvec():
     assert jnp.allclose(Ax, res)
 
 
+def test_matvec_jit():
+    res = jax.jit(mv)(x_local)
+    assert jnp.allclose(Ax, res)
+
+
 def test_matvecT():
     res = mvT(y)
+    assert jnp.allclose(ATy_local, res)
+
+
+def test_matvecT_jit():
+    res = jax.jit(mvT)(y)
     assert jnp.allclose(ATy_local, res)
 
 
@@ -117,9 +127,21 @@ def test_matvec_transpose():
     assert jnp.allclose(ATy_local, res)
 
 
+def test_matvec_transpose_jit():
+    lt = transpose(mv, x_local)
+    res = jax.jit(lt)(y)
+    assert jnp.allclose(ATy_local, res)
+
+
 def test_matvecT_transpose():
     ltT = transpose(mvT, y)
     res = ltT(x_local)
+    assert jnp.allclose(Ax, res)
+
+
+def test_matvecT_transpose_jit():
+    ltT = transpose(mvT, y)
+    res = jax.jit(ltT)(x_local)
     assert jnp.allclose(Ax, res)
 
 
@@ -130,10 +152,24 @@ def test_matvec_transpose2():
     assert jnp.allclose(Ax, res)
 
 
+def test_matvec_transpose2_jit():
+    lt = transpose(mv, x_local)
+    ltlt = transpose(lt, y)
+    res = jax.jit(ltlt)(x_local)
+    assert jnp.allclose(Ax, res)
+
+
 def test_matvecT_transpose2():
     ltT = transpose(mvT, y)
     ltltT = transpose(ltT, x_local)
     res = ltltT(y)
+    assert jnp.allclose(ATy_local, res)
+
+
+def test_matvecT_transpose2_jit():
+    ltT = transpose(mvT, y)
+    ltltT = transpose(ltT, x_local)
+    res = jax.jit(ltltT)(y)
     assert jnp.allclose(ATy_local, res)
 
 
@@ -145,11 +181,27 @@ def test_matvec_transpose3():
     assert jnp.allclose(ATy_local, res)
 
 
+def test_matvec_transpose3_jit():
+    lt = transpose(mv, x_local)
+    ltlt = transpose(lt, y)
+    ltltlt = transpose(ltlt, x_local)
+    res = jax.jit(ltltlt)(y)
+    assert jnp.allclose(ATy_local, res)
+
+
 def test_matvecT_transpose3():
     ltT = transpose(mvT, y)
     ltltT = transpose(ltT, x_local)
     ltltltT = transpose(ltltT, y)
     res = ltltltT(x_local)
+    assert jnp.allclose(Ax, res)
+
+
+def test_matvecT_transpose3_jit():
+    ltT = transpose(mvT, y)
+    ltltT = transpose(ltT, x_local)
+    ltltltT = transpose(ltltT, y)
+    res = jax.jit(ltltltT)(x_local)
     assert jnp.allclose(Ax, res)
 
 
@@ -159,8 +211,20 @@ def test_matvec_jvp():
     assert jnp.allclose(Av, jvp)
 
 
+def test_matvec_jvp_jit():
+    res, jvp = jax.jit(lambda x, v: jax.jvp(mv, (x,), (v,)))(x_local, v_local)
+    assert jnp.allclose(Ax, res)
+    assert jnp.allclose(Av, jvp)
+
+
 def test_matvecT_jvp():
     res, jvp = jax.jvp(mvT, (y,), (vprime,))
+    assert jnp.allclose(ATy_local, res)
+    assert jnp.allclose(ATvprime_local, jvp)
+
+
+def test_matvecT_jvp_jit():
+    res, jvp = jax.jit(lambda y, v: jax.jvp(mvT, (y,), (v,)))(y, vprime)
     assert jnp.allclose(ATy_local, res)
     assert jnp.allclose(ATvprime_local, jvp)
 
@@ -172,8 +236,30 @@ def test_matvec_vjp():
     assert jnp.allclose(ATvprime_local, vjp)
 
 
+def test_matvec_vjp_jit():
+    def f(x, v):
+        res, vjp_fun = jax.vjp(mv, x)
+        (vjp,) = vjp_fun(v)
+        return res, vjp
+
+    res, vjp = jax.jit(f)(x_local, vprime)
+    assert jnp.allclose(Ax, res)
+    assert jnp.allclose(ATvprime_local, vjp)
+
+
 def test_matvecT_vjp():
     res, vjp_fun = jax.vjp(mvT, y)
     (jvp,) = vjp_fun(v_local)
+    assert jnp.allclose(ATy_local, res)
+    assert jnp.allclose(Av, jvp)
+
+
+def test_matvecT_vjp_jit():
+    def f(y, v):
+        res, vjp_fun = jax.vjp(mvT, y)
+        (jvp,) = vjp_fun(v)
+        return res, jvp
+
+    res, jvp = jax.jit(f)(y, v_local)
     assert jnp.allclose(ATy_local, res)
     assert jnp.allclose(Av, jvp)

--- a/tests/test_collective_ops.py
+++ b/tests/test_collective_ops.py
@@ -87,13 +87,10 @@ def test_allreduceT():
 def test_allreduce_transpose():
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
-    (res,) = jax.linear_transpose(
-        lambda x: Allreduce(x, op=MPI.SUM, token=token)[0], arr
-    )(_arr)
+    (res,) = jax.linear_transpose(lambda x: Allreduce(x, op=MPI.SUM)[0], arr)(_arr)
     assert jnp.array_equal(_arr, res)
 
 
@@ -101,15 +98,12 @@ def test_allreduce_transpose2():
     # test transposing twice
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
     _arr2 = arr.copy()
 
     def lt(y):
-        return jax.linear_transpose(
-            lambda x: Allreduce(x, op=MPI.SUM, token=token)[0], arr
-        )(y)[0]
+        return jax.linear_transpose(lambda x: Allreduce(x, op=MPI.SUM)[0], arr)(y)[0]
 
     (res,) = jax.linear_transpose(lt, _arr)(_arr2)
     expected, _ = Allreduce(_arr2, op=MPI.SUM)
@@ -119,12 +113,11 @@ def test_allreduce_transpose2():
 def test_allreduceT_transpose():
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
     (res,) = jax.linear_transpose(
-        lambda x: Allreduce(x, op=MPI.SUM, token=token, _transpose=True)[0], arr
+        lambda x: Allreduce(x, op=MPI.SUM, _transpose=True)[0], arr
     )(_arr)
     expected, _ = Allreduce(_arr, op=MPI.SUM)
     assert jnp.array_equal(expected, res)
@@ -134,14 +127,13 @@ def test_allreduceT_transpose2():
     # test transposing twice
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
     _arr2 = arr.copy()
 
     def lt(y):
         return jax.linear_transpose(
-            lambda x: Allreduce(x, op=MPI.SUM, token=token, _transpose=True)[0], arr
+            lambda x: Allreduce(x, op=MPI.SUM, _transpose=True)[0], arr
         )(y)[0]
 
     (res,) = jax.linear_transpose(lt, _arr)(_arr2)
@@ -167,7 +159,7 @@ def test_allreduce_grad():
     def testfun(x):
         y, token = Allreduce(x, op=MPI.SUM)
         z = x + 2 * y  # noqa: F841
-        res, token2 = Allreduce(x, op=MPI.SUM, token=token)
+        res, token2 = Allreduce(x, op=MPI.SUM)
         return res.sum()
 
     res, grad = jax.jit(jax.value_and_grad(testfun))(arr)
@@ -178,13 +170,10 @@ def test_allreduce_grad():
 def test_allreduce_jvp():
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
-    res, jvp = jax.jvp(
-        lambda x: Allreduce(x, op=MPI.SUM, token=token)[0], (arr,), (_arr,)
-    )
+    res, jvp = jax.jvp(lambda x: Allreduce(x, op=MPI.SUM)[0], (arr,), (_arr,))
 
     expected, _ = Allreduce(arr, op=MPI.SUM)
     assert jnp.array_equal(expected, res)
@@ -195,11 +184,10 @@ def test_allreduce_jvp():
 def test_allreduce_vjp():
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
-    res, vjp_fun = jax.vjp(lambda x: Allreduce(x, op=MPI.SUM, token=token)[0], arr)
+    res, vjp_fun = jax.vjp(lambda x: Allreduce(x, op=MPI.SUM)[0], arr)
     (vjp,) = vjp_fun(_arr)
 
     expected, _ = Allreduce(arr, op=MPI.SUM)
@@ -210,12 +198,11 @@ def test_allreduce_vjp():
 def test_allreduceT_jvp():
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
     res, jvp = jax.jvp(
-        lambda x: Allreduce(x, op=MPI.SUM, token=token, _transpose=True)[0],
+        lambda x: Allreduce(x, op=MPI.SUM, _transpose=True)[0],
         (arr,),
         (_arr,),
     )
@@ -226,13 +213,10 @@ def test_allreduceT_jvp():
 def test_allreduceT_vjp():
     from mpi4jax import Allreduce
 
-    token = jax.lax.create_token(123)
     arr = jnp.ones((3, 2))
     _arr = arr.copy()
 
-    res, vjp_fun = jax.vjp(
-        lambda x: Allreduce(x, op=MPI.SUM, token=token, _transpose=True)[0], arr
-    )
+    res, vjp_fun = jax.vjp(lambda x: Allreduce(x, op=MPI.SUM, _transpose=True)[0], arr)
     (vjp,) = vjp_fun(_arr)
 
     assert jnp.array_equal(arr, res)


### PR DESCRIPTION
Adds tests for the transpose of allreduce & jit which works as of jax 0.2.9.