### PR TITLE
Fix versioning issues

### DIFF
--- a/.git-archival.txt
+++ b/.git-archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.setuptools_scm]
-write_to = "mpi4jax/_version.py"
-
-
 [tool.coverage.run]
 branch = true
 parallel = true
@@ -29,25 +25,16 @@ exclude = '''
 '''
 
 
-# Requirements
-[dependencies]
-Click = "^7.0"
-numpy = ">=1.16"
-jax = ">=0.1.40"
-jaxlib = ">=0.1.55"
-mpi4py = ">=3.0.1"
-
-[dev-dependencies]
-black = { version = "^18.3-alpha.0", python = "^3.6" }
-pre-commit = ">= 2.7"
-pytest = ">= 5"
+# Build requirements
+# (for runtime requirements see setup.py)
 
 [build-system]
 requires = [
-  "setuptools>=18.0",
+  "setuptools>=42",
   "wheel",
   "cython>=0.21",
   "mpi4py>=3.0.1",
   "setuptools_scm[toml]>=3.4",
+  "setuptools_scm_git_archive",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -184,12 +184,9 @@ setup(
     ],
     packages=["mpi4jax", "mpi4jax.collective_ops", "mpi4jax.cython"],
     ext_modules=EXTENSIONS,
-    setup_requires=[
-        "setuptools>=18.0",
-        "cython>=0.21",
-        "mpi4py>=3.0.1",
-        "setuptools_scm",
-    ],
+    use_scm_version=dict(
+        write_to="mpi4jax/_version.py",
+    ),
     python_requires=">=3.6",
     install_requires=["jax", "jaxlib>=0.1.55", "mpi4py>=3.0.1", "numpy"],
     extras_require={"dev": ["pytest", "black", "flake8==3.8.3", "pre-commit>=2"]},


### PR DESCRIPTION
Investigating #49 

Tweaks:
- Move runtime dependencies to `setup.py`. There is no benefit in specifying those twice, and if only `setup.py` is universally supported, so be it.
- Ensure that `setup.py` is aware of `setuptools-scm`.
- Use `setuptools-scm-git-archive` to inject version into GitHub release tarballs.
- Bump minimum setuptools version [as recommended](https://github.com/pypa/setuptools_scm/#pyprojecttoml-usage).