### PR TITLE
flush gpu queue

### DIFF
--- a/mpi4jax/flush.py
+++ b/mpi4jax/flush.py
@@ -4,11 +4,15 @@ import jax
 def flush():
     """Wait for all pending XLA operations"""
     # as suggested in jax#4335
-    for device in jax.devices("cpu"):
-        noop = jax.device_put(0, device=device) + 0
-        noop.block_until_ready()
 
-    # if there are gpus, then also flush there
-    for device in jax.devices():
+    devices = jax.devices("cpu")
+
+    # jax.devices("gpu") throws if no gpu available.
+    try:
+        devices.extend(jax.devices("gpu"))
+    except RuntimeError:
+        pass
+
+    for device in devices:
         noop = jax.device_put(0, device=device) + 0
         noop.block_until_ready()

--- a/mpi4jax/flush.py
+++ b/mpi4jax/flush.py
@@ -7,3 +7,8 @@ def flush():
     for device in jax.devices("cpu"):
         noop = jax.device_put(0, device=device) + 0
         noop.block_until_ready()
+
+    # if there are gpus, then also flush there
+    for device in jax.devices():
+        noop = jax.device_put(0, device=device) + 0
+        noop.block_until_ready()


### PR DESCRIPTION
It's not nice, and it will flush twice the cpu if we only have cpus, but jax does not have a stable api to get a list of all devices.
I think it's ok for now?