### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,11 @@
 include versioneer.py
 include mpi4jax/_version.py
 
-global-include *.pyx
-global-include *.pxd
-global-exclude *.c
+recursive-include mpi4jax *.pyx *.pxd
+recursive-exclude mpi4jax *.c
 
-include tests
-include examples
+recursive-include tests *.py
+recursive-include examples *.py
+
 include LICENSE.md
 include README.rst


### PR DESCRIPTION
This should catch everything, but better to double-check.

```bash
$ python setup.py sdist
**************************************************
*** WARNING: CUDA path not found
*** WARNING: (GPU extensions will not be built)
**************************************************
running sdist
running egg_info
writing mpi4jax.egg-info/PKG-INFO
writing dependency_links to mpi4jax.egg-info/dependency_links.txt
writing requirements to mpi4jax.egg-info/requires.txt
writing top-level names to mpi4jax.egg-info/top_level.txt
reading manifest file 'mpi4jax.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'mpi4jax.egg-info/SOURCES.txt'
running check
creating mpi4jax-0.2.15+1.g1074e0c.dirty
creating mpi4jax-0.2.15+1.g1074e0c.dirty/examples
creating mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax
creating mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax.egg-info
creating mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
creating mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
creating mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
creating mpi4jax-0.2.15+1.g1074e0c.dirty/tests
creating mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying files to mpi4jax-0.2.15+1.g1074e0c.dirty...
copying LICENSE.md -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying MANIFEST.in -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying README.rst -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying pyproject.toml -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying setup.cfg -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying setup.py -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying versioneer.py -> mpi4jax-0.2.15+1.g1074e0c.dirty
copying examples/shallow_water.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/examples
copying mpi4jax/__init__.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax
copying mpi4jax/_deprecations.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax
copying mpi4jax/_version.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax
copying mpi4jax.egg-info/PKG-INFO -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax.egg-info
copying mpi4jax.egg-info/SOURCES.txt -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax.egg-info
copying mpi4jax.egg-info/dependency_links.txt -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax.egg-info
copying mpi4jax.egg-info/requires.txt -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax.egg-info
copying mpi4jax.egg-info/top_level.txt -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax.egg-info
copying mpi4jax/_src/__init__.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
copying mpi4jax/_src/comm.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
copying mpi4jax/_src/decorators.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
copying mpi4jax/_src/flush.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
copying mpi4jax/_src/utils.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
copying mpi4jax/_src/validation.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src
copying mpi4jax/_src/collective_ops/__init__.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/allgather.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/allreduce.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/alltoall.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/bcast.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/gather.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/recv.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/reduce.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/scan.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/scatter.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/send.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/collective_ops/sendrecv.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/collective_ops
copying mpi4jax/_src/xla_bridge/__init__.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
copying mpi4jax/_src/xla_bridge/cuda_runtime_api.pxd -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
copying mpi4jax/_src/xla_bridge/mpi_xla_bridge.pxd -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
copying mpi4jax/_src/xla_bridge/mpi_xla_bridge.pyx -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
copying mpi4jax/_src/xla_bridge/mpi_xla_bridge_cpu.pyx -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
copying mpi4jax/_src/xla_bridge/mpi_xla_bridge_gpu.pyx -> mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_src/xla_bridge
copying tests/conftest.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/test_decorators.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/test_deprecations.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/test_examples.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/test_flush.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/test_invalid_jaxlib.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/test_validation.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests
copying tests/collective_ops/test_allgather.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_allreduce.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_allreduce_matvec.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_alltoall.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_bcast.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_common.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_gather.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_reduce.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_scan.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_scatter.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_send_and_recv.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
copying tests/collective_ops/test_sendrecv.py -> mpi4jax-0.2.15+1.g1074e0c.dirty/tests/collective_ops
Writing mpi4jax-0.2.15+1.g1074e0c.dirty/setup.cfg
UPDATING mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_version.py
set mpi4jax-0.2.15+1.g1074e0c.dirty/mpi4jax/_version.py to '0.2.15+1.g1074e0c.dirty'
Creating tar archive
removing 'mpi4jax-0.2.15+1.g1074e0c.dirty' (and everything under it)
```

Looks complete to me. Or does the conda recipe need other stuff such as `conf` or `docs`?