### PR TITLE
Do not free default comm on exit

### DIFF
--- a/mpi4jax/_src/comm.py
+++ b/mpi4jax/_src/comm.py
@@ -1,4 +1,3 @@
-
 _default_comm = None
 
 
@@ -6,6 +5,7 @@ def get_default_comm():
     global _default_comm
     if _default_comm is None:
         from mpi4py import MPI
+
         _default_comm = MPI.COMM_WORLD.Clone()
 
     return _default_comm

--- a/mpi4jax/_src/comm.py
+++ b/mpi4jax/_src/comm.py
@@ -1,16 +1,12 @@
-import atexit
-import threading
 
-_default_comm = threading.local()
-_default_comm.value = None
+_default_comm = None
 
 
 def get_default_comm():
-    if _default_comm.value is None:
+    global _default_comm
+    if _default_comm is None:
         from mpi4py import MPI
 
-        default_comm = MPI.COMM_WORLD.Clone()
-        atexit.register(default_comm.Free)
-        _default_comm.value = default_comm
+        _default_comm = MPI.COMM_WORLD.Clone()
 
-    return _default_comm.value
+    return _default_comm

--- a/mpi4jax/_src/comm.py
+++ b/mpi4jax/_src/comm.py
@@ -6,7 +6,6 @@ def get_default_comm():
     global _default_comm
     if _default_comm is None:
         from mpi4py import MPI
-
         _default_comm = MPI.COMM_WORLD.Clone()
 
     return _default_comm


### PR DESCRIPTION
I think it isn't safe to do this in `atexit`, since we don't know whether it will run before or after any pending MPI operations. So let's just leave the cleanup to `mpi4py`.